### PR TITLE
Add option avoid QtWebEngineWidgets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+v1.2.5
+======
+- Add option to start the GUI without importing QtWebEngineWidgets
+  `#10 <https://github.com/psyplot/psyplot-gui/pull/10>`__
 v1.2.4
 ======
 New release with better OpenGL support (see ``psyplot --help``)

--- a/psyplot_gui/__init__.py
+++ b/psyplot_gui/__init__.py
@@ -75,7 +75,7 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
               exclude_plugins=rcParams['plugins.exclude'], offline=False,
               pwd=None, script=None, command=None, exec_=True, use_all=False,
               callback=None,
-              opengl_implementation=None):
+              opengl_implementation=None, webengineview=True):
     """
     Eventually start the QApplication or only make a plot
 
@@ -126,6 +126,10 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
         OpenGL implementation to pass to Qt. Possible options are
         'software', 'desktop', 'gles' and 'automatic' (which let's PyQt
         decide).
+    webengineview: bool
+        If True (default), use an HTML help widget. This might not be available
+        for all builds of PyQt5 under all circumstances. If not set, the
+        rcParams key ``'help_explorer.use_webengineview'`` is used.
 
     Returns
     -------
@@ -149,6 +153,8 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
     # set plugins
     rcParams['plugins.include'] = include_plugins
     rcParams['plugins.exclude'] = exclude_plugins
+    if webengineview is not None:
+        rcParams['help_explorer.use_webengineview'] = webengineview
 
     if offline:
         rcParams['help_explorer.online'] = False
@@ -345,6 +351,16 @@ def get_parser(create=True):
 
     parser.pop_arg('exec_')
     parser.pop_arg('callback')
+
+    parser.pop_key('webengineview', 'short')
+    parser.update_arg('webengineview', default=None, action='store_true',
+                      group=gui_grp)
+
+    parser.unfinished_arguments['no-webengineview'] = dict(
+        long='no-webengineview', default=None, action='store_false',
+        dest='webengineview',
+        help="Do not use HTML rendering.",
+        group=gui_grp)
 
     if psyplot.__version__ < '1.0':
         parser.set_main(start_app)

--- a/psyplot_gui/compat/qtcompat.py
+++ b/psyplot_gui/compat/qtcompat.py
@@ -4,6 +4,7 @@
 # loaded
 import six
 import sys
+from psyplot_gui.config.rcsetup import rcParams
 
 try:
     from qtconsole.rich_jupyter_widget import RichJupyterWidget
@@ -84,10 +85,13 @@ else:
         QKeySequence)
     from PyQt5 import QtCore
     from PyQt5.QtCore import Qt, QSortFilterProxyModel
-    try:
-        from PyQt5.QtWebEngineWidgets import QWebEngineView
-    except ImportError:
-        from PyQt5.QtWebKitWidgets import QWebView as QWebEngineView
+    if rcParams['help_explorer.use_webengineview']:
+        try:
+            from PyQt5.QtWebEngineWidgets import QWebEngineView
+        except ImportError:
+            from PyQt5.QtWebKitWidgets import QWebView as QWebEngineView
+    else:
+        QWebEngineView = None
     from PyQt5.QtTest import QTest, QSignalSpy
     from PyQt5 import QtGui
     from PyQt5.Qt import PYQT_VERSION_STR as PYQT_VERSION

--- a/psyplot_gui/config/rcsetup.py
+++ b/psyplot_gui/config/rcsetup.py
@@ -178,6 +178,10 @@ defaultParams = {
         'backend is used and no changes are made. Note that it is usually not '
         'possible to change the backend after importing the psyplot.project '
         'module. The default backend embeds the figures into the '],
+    'help_explorer.use_webengineview': [
+        True, validate_bool,
+        "Enable the PyQt5.QtWebEngineWidgets.QWebEngineView which might not "
+        "work under certain circumstances."],
     'help_explorer.use_intersphinx': [
         None, validate_bool_maybe_none,
         'Use the intersphinx extension and link to the online documentations '

--- a/psyplot_gui/help_explorer.py
+++ b/psyplot_gui/help_explorer.py
@@ -933,6 +933,9 @@ class HelpExplorer(QWidget, DockMixin):
     #: instance
     viewers = OrderedDict([('HTML help', UrlHelp), ('Plain text', TextHelp)])
 
+    if not rcParams['help_explorer.use_webengineview']:
+        del viewers['HTML help']
+
     def __init__(self, *args, **kwargs):
         super(HelpExplorer, self).__init__(*args, **kwargs)
         self.vbox = vbox = QVBoxLayout()
@@ -1069,6 +1072,6 @@ class HelpExplorer(QWidget, DockMixin):
     def close(self, *args, **kwargs):
         try:
             self.viewers['HTML help'].close(*args, **kwargs)
-        except AttributeError:
+        except (KeyError, AttributeError):
             pass
         return super(HelpExplorer, self).close(*args, **kwargs)

--- a/psyplot_gui/main.py
+++ b/psyplot_gui/main.py
@@ -359,7 +359,8 @@ class MainWindow(QMainWindow):
         self.figures_tree = FiguresTree(parent=self)
         #: help explorer
         self.help_explorer = help_explorer = HelpExplorer(parent=self)
-        if help_explorer.viewers['HTML help'].sphinx_thread is not None:
+        if 'HTML help' in help_explorer.viewers and help_explorer.viewers[
+                'HTML help'].sphinx_thread is not None:
             help_explorer.viewers[
                 'HTML help'].sphinx_thread.html_ready.connect(
                     self.focus_on_console)

--- a/tests/test_help_explorer.py
+++ b/tests/test_help_explorer.py
@@ -7,7 +7,7 @@ import _base_testing as bt
 import dummy_module as d
 from psyplot_gui import rcParams
 from psyplot_gui.compat.qtcompat import QTest, Qt, asstring
-from psyplot_gui.help_explorer import html2file, UrlHelp
+from psyplot_gui.help_explorer import html2file, UrlHelp, HelpExplorer
 
 
 class UrlHelpTestMixin(bt.PsyPlotGuiTestCase):
@@ -235,6 +235,23 @@ class TextHelpTest(bt.PsyPlotGuiTestCase):
         """Test whether the sphinx rendering works for a instance of a class"""
         ini = d.DummyClass()
         self._test_object_docu(ini, 'ini')
+
+
+class NoHTMLTest(TextHelpTest):
+    """Test running without the HTML viewer"""
+
+    @classmethod
+    def setUpClass(cls):
+        rcParams['help_explorer.use_webengineview'] = False
+        del HelpExplorer.viewers['HTML help']
+
+    def setUp(self):
+        super(TextHelpTest, self).setUp()
+
+    @classmethod
+    def tearDownClass(cls):
+        rcParams['help_explorer.use_webengineview'] = True
+        HelpExplorer.viewers['HTML help'] = UrlHelp
 
 
 if __name__ == '__main__':

--- a/tests/test_help_explorer.py
+++ b/tests/test_help_explorer.py
@@ -7,7 +7,8 @@ import _base_testing as bt
 import dummy_module as d
 from psyplot_gui import rcParams
 from psyplot_gui.compat.qtcompat import QTest, Qt, asstring
-from psyplot_gui.help_explorer import html2file, UrlHelp, HelpExplorer
+from psyplot_gui.help_explorer import (
+    html2file, UrlHelp, HelpExplorer, _viewers)
 
 
 class UrlHelpTestMixin(bt.PsyPlotGuiTestCase):
@@ -242,8 +243,11 @@ class NoHTMLTest(TextHelpTest):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         rcParams['help_explorer.use_webengineview'] = False
         del HelpExplorer.viewers['HTML help']
+        cls._orig_viewers = _viewers.copy()
+        _viewers.clear()
 
     def setUp(self):
         super(TextHelpTest, self).setUp()
@@ -252,6 +256,13 @@ class NoHTMLTest(TextHelpTest):
     def tearDownClass(cls):
         rcParams['help_explorer.use_webengineview'] = True
         HelpExplorer.viewers['HTML help'] = UrlHelp
+        for key, val in cls._orig_viewers.items():
+            _viewers[key] = val
+        super().tearDownClass()
+
+    def test_no_html(self):
+        """Test if the HTML help has been removed"""
+        self.assertNotIn('HTML help', self.help_explorer.viewers)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes

This PR adds the possibilities to avoid importing `PyQt5.QtWebEngineWidgets` and disable the HTML help (Plain text help is still available). Here we implement:

- a new `rcParams` key ``'help_explorer.use_webengineview'``, which defaults to `True`
- the new command-line options `psyplot --webengineview` and `psyplot --no-webengineview` to override the `rcParams`