### PR TITLE
Add DockMixin.position_dock and reset of expanded items

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ commands:
             conda config --add channels psyplot
             conda update -q conda
             conda install conda-build anaconda-client conda-verify
-            if [[ $CIRCLE_TAG == "" ]]; then conda config --add channels psyplot/label/${CIRCLE_BRANCH}; fi
+            if [[ $CIRCLE_TAG == "" ]]; then
+              conda config --add channels psyplot/label/master;
+              conda config --add channels psyplot/label/${CIRCLE_BRANCH};
+            fi
       - run:
           name: Environment info
           command: |
@@ -93,6 +96,6 @@ workflows:
       - build_linux
       - build_linux:
           python_version: "3.7"
-      - build_windows
-      - build_windows:
-          python_version: "3.7"
+#      - build_windows
+#      - build_windows:
+#          python_version: "3.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ commands:
             conda config --add channels psyplot
             conda update -q conda
             conda install conda-build anaconda-client conda-verify
-            if [[ $CIRCLE_TAG == "" ]]; then
+            if [[ $CIRCLE_PULL_REQUEST == "" ]]; then
+              conda config --add channels psyplot/label/master;
+            elif [[ $CIRCLE_TAG == "" ]]; then
               conda config --add channels psyplot/label/master;
               conda config --add channels psyplot/label/${CIRCLE_BRANCH};
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
             conda config --add channels psyplot
             conda update -q conda
             conda install conda-build anaconda-client conda-verify
-            if [[ $CIRCLE_PULL_REQUEST == "" ]]; then
+            if [[ $CIRCLE_PULL_REQUEST != "" ]]; then
               conda config --add channels psyplot/label/master;
             elif [[ $CIRCLE_TAG == "" ]]; then
               conda config --add channels psyplot/label/master;

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ v1.2.5
   see `#10 <https://github.com/psyplot/psyplot-gui/pull/10>`__
 - Add option to start the GUI without importing QtWebEngineWidgets
   `#11 <https://github.com/psyplot/psyplot-gui/pull/11>`__
+- Dockmixins (i.e. plugins) can now reimplement the `position_dock` method that
+  controls where the dock is exactly placed in the GUI
+  (see `#12 <https://github.com/psyplot/psyplot-gui/pull/12>`__)
 
 v1.2.4
 ======

--- a/psyplot_gui/common.py
+++ b/psyplot_gui/common.py
@@ -95,11 +95,24 @@ class DockMixin(object):
             main.dockwidgets.append(self.dock)
             self.create_central_widget_action(main)
             self.create_view_action(main, docktype)
-        main.addDockWidget(position, self.dock, *args, **kwargs)
+        self.position_dock(main, *args, **kwargs)
         config_page = self.config_page
         if config_page is not None:
             main.config_pages.append(config_page)
         return self.dock
+
+    def position_dock(self, main, *args, **kwargs):
+        """Set the position of the dock widget
+
+        This method places the plugin widget at the desired dock position
+        (by default, indicated with the :attr:`dock_position` attribute)
+
+        Parameters
+        ----------
+        main: psyplot_gui.main.Mainwindow
+            The main window where the dock is added"""
+        main.addDockWidget(self.dock_position, self.dock, *args, **kwargs)
+
 
     def show_plugin(self):
         """Show the plugin widget"""

--- a/tests/test_project_content.py
+++ b/tests/test_project_content.py
@@ -249,6 +249,20 @@ class DatasetTreeTest(bt.PsyPlotGuiTestCase):
         self._test_ds_representation(ds)
         self._test_ds_representation(ds2)
 
+    def test_expansion_reset(self):
+        """Test whether the expansion state is recovered"""
+        fname = self.get_file('test-t2m-u-v.nc')
+        psy.plot.plot2d(fname, name='t2m')
+        self.tree.expandItem(self.tree.topLevelItem(0))
+        self.tree.expandItem(self.tree.topLevelItem(0).child(1))
+
+        # trigger an update
+        psy.plot.plot2d(fname, name='t2m')
+        self.assertTrue(self.tree.topLevelItem(0).isExpanded())
+        self.assertFalse(self.tree.topLevelItem(0).child(0).isExpanded())
+        self.assertTrue(self.tree.topLevelItem(0).child(1).isExpanded())
+        self.assertFalse(self.tree.topLevelItem(0).child(2).isExpanded())
+
     def test_make_plot(self):
         """Test the making of plots"""
         fname = self.get_file('test-t2m-u-v.nc')


### PR DESCRIPTION
This method adds a new method to the DockMixin to set the position of the DockWidget. By default, this is implemented as

```python
    def position_dock(self, main, *args, **kwargs):
        main.addDockWidget(self.dock_position, self.dock, *args, **kwargs)
```
and called in the `to_dock` method.

Furthermore, the `DatasetTree` now does not collapse the items anymore after the project as been updated.

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
