### PR TITLE
Add preset functionality to GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ target/
 
 # conda build files
 ci/conda_recipe/psyplot-gui/meta.yaml
+ci/conda-recipe/recipe_append.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ install:
         conda install conda-build anaconda-client conda-verify
     - if [[ $TRAVIS_TAG == "" ]]; then
         export GIT_BRANCH=$TRAVIS_BRANCH;
+        conda config --add channels psyplot/label/master;
         conda config --add channels psyplot/label/${TRAVIS_BRANCH};
       fi
     - python ci/setup_append.py ci/conda-recipe pyqt=${QT_VERSION}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Changed
 
 Added
 -----
+- The psyplot gui can now load and save preset files,
+  see `psyplot#24 <https://github.com/psyplot/psyplot/pull/24>`__ and
+  `#17 https://github.com/psyplot/psyplot-gui/pull/17`__
 - Add option to start the GUI without importing QtWebEngineWidgets
   `#11 <https://github.com/psyplot/psyplot-gui/pull/11>`__
 - Dockmixins (i.e. plugins) can now reimplement the `position_dock` method that

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
     - cmd: endlocal
     - cmd: 'SET PYTHONWARNINGS=ignore:mode:DeprecationWarning:docutils.io:245'
     - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (SET GIT_BRANCH=%APPVEYOR_REPO_BRANCH%)"
+    - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (conda config --add channels psyplot/label/master)"
     - cmd: "IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (conda config --add channels psyplot/label/%APPVEYOR_REPO_BRANCH%)"
     - cmd: python ci\\setup_append.py ci\\conda-recipe pyqt=%QT_VERSION%
 

--- a/psyplot_gui/__init__.py
+++ b/psyplot_gui/__init__.py
@@ -3,6 +3,8 @@ import sys
 import os
 import os.path as osp
 import six
+import tempfile
+import yaml
 import socket
 import atexit
 import fasteners
@@ -175,6 +177,21 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
         name = 'all'
     else:
         name = safe_list(name)
+
+    if formatoptions is not None:
+        if not isinstance(formatoptions, dict):
+            # list of dicts
+            for fmt in formatoptions[1:]:
+                formatoptions[0].update(fmt)
+            formatoptions = formatoptions[0]
+        if preset is not None:
+            preset_data = psy.Project._load_preset(preset)
+        else:
+            preset_data = {}
+        preset_data.update(formatoptions)
+        preset = tempfile.NamedTemporaryFile(prefix='psy_', suffix='.yml').name
+        with open(preset, 'w') as f:
+            yaml.dump(preset_data, f)
 
     # Lock file creation
     if not new_instance:

--- a/psyplot_gui/__init__.py
+++ b/psyplot_gui/__init__.py
@@ -74,7 +74,7 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
               rc_gui_file=None, include_plugins=rcParams['plugins.include'],
               exclude_plugins=rcParams['plugins.exclude'], offline=False,
               pwd=None, script=None, command=None, exec_=True, use_all=False,
-              callback=None,
+              callback=None, preset=None,
               opengl_implementation=None, webengineview=True):
     """
     Eventually start the QApplication or only make a plot
@@ -170,7 +170,7 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
             formatoptions=formatoptions, tight=tight, rc_file=rc_file,
             encoding=encoding, enable_post=enable_post,
             seaborn_style=seaborn_style, output_project=output_project,
-            concat_dim=concat_dim, chname=chname)
+            concat_dim=concat_dim, chname=chname, preset=preset)
     if use_all:
         name = 'all'
     else:
@@ -210,7 +210,8 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
         if callback:
             send_files_to_psyplot(
                 callback, fnames, project, engine, plot_method, name, dims,
-                encoding, enable_post, seaborn_style, concat_dim, chname)
+                encoding, enable_post, seaborn_style, concat_dim, chname,
+                preset)
         return
     elif new_instance:
         rcParams['main.listen_to_port'] = False
@@ -231,7 +232,7 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
     else:
         mainwindow = MainWindow.run(fnames, project, engine, plot_method, name,
                                     dims, encoding, enable_post, seaborn_style,
-                                    concat_dim, chname)
+                                    concat_dim, chname, preset)
     if script is not None:
         mainwindow.console.run_script_in_shell(script)
     if command is not None:

--- a/psyplot_gui/__init__.py
+++ b/psyplot_gui/__init__.py
@@ -185,6 +185,7 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
                 formatoptions[0].update(fmt)
             formatoptions = formatoptions[0]
         if preset is not None:
+            import psyplot.project as psy
             preset_data = psy.Project._load_preset(preset)
         else:
             preset_data = {}
@@ -192,6 +193,11 @@ def start_app(fnames=[], name=[], dims=None, plot_method=None,
         preset = tempfile.NamedTemporaryFile(prefix='psy_', suffix='.yml').name
         with open(preset, 'w') as f:
             yaml.dump(preset_data, f)
+
+    # make preset path absolute
+    if preset is not None and not isinstance(preset, dict) and \
+            osp.exists(preset):
+        preset = osp.abspath(preset)
 
     # Lock file creation
     if not new_instance:

--- a/psyplot_gui/common.py
+++ b/psyplot_gui/common.py
@@ -277,6 +277,10 @@ class PyErrorMessage(QErrorMessage):
     method"""
 
     def showTraceback(self, header=None):
+
+        if is_running_tests():
+            raise
+
         s = io.StringIO()
         tb.print_exc(file=s)
         last_tb = '<p>' + '<br>'.join(s.getvalue().splitlines()) + \

--- a/tests/test_dataframeeditor.py
+++ b/tests/test_dataframeeditor.py
@@ -110,10 +110,6 @@ class DataFrameEditorTest(bt.PsyPlotGuiTestCase):
         self.assertTrue(self.model.sort(0, return_check=True))
         self.assertEqual(list(df.index.values), [0, 1])
 
-        # test false sorting
-        if not six.PY2:
-            self.assertFalse(self.model.sort(2, return_check=True))
-
         # test complex numbers
         self.assertTrue(self.model.sort(3, Qt.AscendingOrder,
                                         return_check=True))
@@ -135,7 +131,22 @@ class DataFrameEditorTest(bt.PsyPlotGuiTestCase):
         self.table.sortByColumn(1)
         self.assertEqual(list(df['a']), [4, 1])
 
+    @unittest.expectedFailure
+    def test_sort_failure(self):
+        df = pd.DataFrame([[4, 5, 6+1j], [1, object, 3]], columns=list('abc'))
+        self.editor.set_df(df)
+
+        # test false sorting
+        if not six.PY2:
+            self.assertFalse(self.model.sort(2, return_check=True))
+
+    @unittest.expectedFailure
+    def test_sort_failure_2(self):
+        df = pd.DataFrame([[4, 5, 6+1j], [1, object, 3]], columns=list('abc'))
+        self.editor.set_df(df)
+
         # test a column that cannot be sorted
+        self.table.setSortingEnabled(True)
         self.table.sortByColumn(2)
 
     def test_edit(self):
@@ -248,6 +259,9 @@ class DataFrameEditorTest(bt.PsyPlotGuiTestCase):
         df.to_csv(f.name, index=False)
         self.editor.open_dataframe(f.name)
         self.assertIsNone(df_equals(self.model.df, df))
+
+    @unittest.expectedFailure
+    def test_open_nonexistent(self):
         self.editor.open_dataframe(u'NONEXISTENT.csv')
         self.assertIsNone(df_equals(self.model.df, df))
 


### PR DESCRIPTION
This PR adds the preset functionality to the GUI that was implemented in psyplot/psyplot#24. We have a new entry in the File menu, and it can be loaded via `psyplot --preset` from the command line

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
